### PR TITLE
Change signal to signal producer. Fix framework search path

### DIFF
--- a/Example/ReactiveMoyaExample.xcodeproj/project.pbxproj
+++ b/Example/ReactiveMoyaExample.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					/Users/justinmakaila/Workspace/Swift/ReactiveMoya/Carthage/Build/iOS,
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = ReactiveMoyaExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -475,7 +475,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					/Users/justinmakaila/Workspace/Swift/ReactiveMoya/Carthage/Build/iOS,
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = ReactiveMoyaExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
The framework search path in the example project was fixed and prevented it to build.

Changed signal mapping to signal producer mappings since the request returns a signal producer and not a signal. 
